### PR TITLE
Fixed height issue for `side-nav-outer-toolbar`.

### DIFF
--- a/src/layouts/side-nav-outer-toolbar/side-nav-outer-toolbar.scss
+++ b/src/layouts/side-nav-outer-toolbar/side-nav-outer-toolbar.scss
@@ -2,6 +2,7 @@
   flex-direction: column;
   display: flex;
   height: 100%;
+  overflow: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
`.side-nav-outer-toolbar` was not stretching to the height of its children, adding `overflow: auto` fixed it.  Notice the whitespace at the bottom of the "before" image.

Before:
![before](https://user-images.githubusercontent.com/26366953/101566880-cacccc00-399d-11eb-9944-500f5d8bacd8.png)

After:
![after](https://user-images.githubusercontent.com/26366953/101566877-c9030880-399d-11eb-8856-5af20d7d98af.png)
